### PR TITLE
Stop rescueing on ::NoMethodFound exception

### DIFF
--- a/lib/omniauth/strategies/oauth.rb
+++ b/lib/omniauth/strategies/oauth.rb
@@ -61,7 +61,7 @@ module OmniAuth
         fail!(:service_unavailable, e)
       rescue ::OAuth::Unauthorized => e
         fail!(:invalid_credentials, e)
-      rescue ::NoMethodError, ::MultiJson::DecodeError => e
+      rescue ::MultiJson::DecodeError => e
         fail!(:invalid_response, e)
       rescue ::OmniAuth::NoSessionError => e
         fail!(:session_expired, e)


### PR DESCRIPTION
If you catch the exception, than people using the gem not see the `NoMethodFound` error that they created by not getting the keys right in the hash.  Instead, it will redirect to the failure callback with an `invalid_response` message.  This will lead people to believe that their keys are wrong or something is wrong with the service instead finding out that they are not getting the data out of the omniauth hash right.

Hopefully removing it doesn't have any unintended consequences, but the oauth2 gem doesn't catch it, so it should be fine.
