### PR TITLE
:request_params option for passing content to get_request_token

### DIFF
--- a/lib/omniauth/strategies/oauth.rb
+++ b/lib/omniauth/strategies/oauth.rb
@@ -14,6 +14,7 @@ module OmniAuth
       option :open_timeout, 30
       option :read_timeout, 30
       option :authorize_params, {}
+      option :request_params, {}
 
       attr_reader :access_token
 
@@ -25,7 +26,7 @@ module OmniAuth
       end
 
       def request_phase
-        request_token = consumer.get_request_token(:oauth_callback => callback_url)
+        request_token = consumer.get_request_token({:oauth_callback => callback_url}, options.request_params)
         session['oauth'] ||= {}
         session['oauth'][name.to_s] = {'callback_confirmed' => request_token.callback_confirmed?, 'request_token' => request_token.token, 'request_secret' => request_token.secret}
 

--- a/spec/omniauth/strategies/oauth_spec.rb
+++ b/spec/omniauth/strategies/oauth_spec.rb
@@ -12,6 +12,7 @@ describe "OmniAuth::Strategies::OAuth" do
       use OmniAuth::Builder do
         provider MyOAuthProvider, 'abc', 'def', :client_options => {:site => 'https://api.example.org'}, :name => 'example.org'
         provider MyOAuthProvider, 'abc', 'def', :client_options => {:site => 'https://api.example.org'}, :authorize_params => {:abc => 'def'}, :name => 'example.org_with_authorize_params'
+        provider MyOAuthProvider, 'abc', 'def', :client_options => {:site => 'https://api.example.org'}, :request_params => {:scope => 'http://foobar.example.org'}, :name => 'example.org_with_request_params'
       end
       run lambda { |env| [404, {'Content-Type' => 'text/plain'}, [env.key?('omniauth.auth').to_s]] }
     }.to_app
@@ -52,6 +53,12 @@ describe "OmniAuth::Strategies::OAuth" do
 
       it 'should set appropriate session variables' do
         session['oauth'].should == {"example.org" => {'callback_confirmed' => true, 'request_token' => 'yourtoken', 'request_secret' => 'yoursecret'}}
+      end
+
+      it 'should pass request_params to get_request_token' do
+        get '/auth/example.org_with_request_params'
+        WebMock.should have_requested(:post, 'https://api.example.org/oauth/request_token').
+           with {|req| req.body == "scope=http%3a%2f%2ffoobar.example.org" }
       end
     end
 


### PR DESCRIPTION
This is required by the YouTube OAuth strategy, which has to pass a custom :scope variable with the request token. 

In Omniauth 0.3 I accomplished this by overloading the request_phase method. Bad juju

https://github.com/jamiew/omniauth-youtube
