### PR TITLE
Add support for Proc args to consumer key/secret

### DIFF
--- a/lib/omniauth/strategies/oauth.rb
+++ b/lib/omniauth/strategies/oauth.rb
@@ -19,7 +19,19 @@ module OmniAuth
       attr_reader :access_token
 
       def consumer
-        consumer = ::OAuth::Consumer.new(options.consumer_key, options.consumer_secret, options.client_options)
+        if options.consumer_key.is_a?(Proc)
+          consumer_key = options.consumer_key.call(env)
+        else
+          consumer_key = options.consumer_key
+        end
+
+        if options.consumer_secret.is_a?(Proc)
+          consumer_secret = options.consumer_secret.call(env)
+        else
+          consumer_secret = options.consumer_secret
+        end
+
+        consumer = ::OAuth::Consumer.new(consumer_key, consumer_secret, options.client_options)
         consumer.http.open_timeout = options.open_timeout if options.open_timeout
         consumer.http.read_timeout = options.read_timeout if options.read_timeout
         consumer


### PR DESCRIPTION
Allows the use of a Proc as a `consumer_key` and `consumer_secret` argument when initializing an OAuth strategy. This Proc receives the Rack env as an argument, allowing variable configuration based on things like a what domain it is being called on.

Wrote this up to solve a problem for a site I'm working on that requires authenticating against different endpoints depending on what domain the request comes from. Feedback greatly appreciated!
