### PR TITLE
Handle invalid consumer credentials during request phase

### DIFF
--- a/lib/omniauth/strategies/oauth.rb
+++ b/lib/omniauth/strategies/oauth.rb
@@ -39,6 +39,8 @@ module OmniAuth
         fail!(:timeout, e)
       rescue ::Net::HTTPFatalError, ::OpenSSL::SSL::SSLError => e
         fail!(:service_unavailable, e)
+      rescue ::OAuth::Unauthorized => e
+        fail!(:invalid_credentials, e)
       end
 
       def callback_phase # rubocop:disable MethodLength

--- a/spec/omniauth/strategies/oauth_spec.rb
+++ b/spec/omniauth/strategies/oauth_spec.rb
@@ -86,6 +86,20 @@ describe "OmniAuth::Strategies::OAuth" do
           last_request.env["omniauth.error.type"] = :service_unavailable
         end
       end
+
+      context "invalid consumer credentials" do
+        before do
+          dummy_response_object = Struct.new(:code, :message).new(401, "Unauthorized")
+          stub_request(:post, "https://api.example.org/oauth/request_token").
+            to_raise(::OAuth::Unauthorized.new(dummy_response_object))
+          get "/auth/example.org"
+        end
+
+        it "should call fail! with :invalid_credentials" do
+          expect(last_request.env["omniauth.error"]).to be_kind_of(::OAuth::Unauthorized)
+          last_request.env["omniauth.error.type"] = :invalid_credentials
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Encountered an `OAuth::Unauthorized` exception during the request phase, when passing invalid credentials. Specifically, when using the [omniauth-desk gem](https://github.com/tstachl/omniauth-desk). Here's the relevant part of the stacktrace:

![](https://www.dropbox.com/s/zgw76co8eobmihw/Screenshot%202015-07-11%2014.42.38.png?dl=1)

It seems like this could happen in other OAuth 1 stategies too, when the consumer is constructed. I'm not 100% sure if `:invalid_credentials` is the right failure code, but it seems like the closest since this is about invalid credentials (only for the consumer).
