### PR TITLE
Expire session if oauth name is missing in rack.session

### DIFF
--- a/lib/omniauth/strategies/oauth.rb
+++ b/lib/omniauth/strategies/oauth.rb
@@ -42,7 +42,7 @@ module OmniAuth
       end
 
       def callback_phase # rubocop:disable MethodLength
-        fail(OmniAuth::NoSessionError, "Session Expired") if session["oauth"].nil?
+        fail(OmniAuth::NoSessionError, "Session Expired") if session["oauth"].nil? || session["oauth"][name.to_s].nil?
 
         request_token = ::OAuth::RequestToken.new(consumer, session["oauth"][name.to_s].delete("request_token"), session["oauth"][name.to_s].delete("request_secret"))
 

--- a/spec/omniauth/strategies/oauth_spec.rb
+++ b/spec/omniauth/strategies/oauth_spec.rb
@@ -107,7 +107,7 @@ describe "OmniAuth::Strategies::OAuth" do
 
     context "bad gateway (or any 5xx) for access_token" do
       before do
-        stub_request(:post, "https://api.example.org/oauth/access_token")  .
+        stub_request(:post, "https://api.example.org/oauth/access_token").
           to_raise(::Net::HTTPFatalError.new('502 "Bad Gateway"', nil))
         get "/auth/example.org/callback", {:oauth_verifier => "dudeman"}, "rack.session" => {"oauth" => {"example.org" => {"callback_confirmed" => true, "request_token" => "yourtoken", "request_secret" => "yoursecret"}}}
       end
@@ -120,7 +120,7 @@ describe "OmniAuth::Strategies::OAuth" do
 
     context "SSL failure" do
       before do
-        stub_request(:post, "https://api.example.org/oauth/access_token")  .
+        stub_request(:post, "https://api.example.org/oauth/access_token").
           to_raise(::OpenSSL::SSL::SSLError.new("SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed"))
         get "/auth/example.org/callback", {:oauth_verifier => "dudeman"}, "rack.session" => {"oauth" => {"example.org" => {"callback_confirmed" => true, "request_token" => "yourtoken", "request_secret" => "yoursecret"}}}
       end

--- a/spec/omniauth/strategies/oauth_spec.rb
+++ b/spec/omniauth/strategies/oauth_spec.rb
@@ -144,4 +144,17 @@ describe "OmniAuth::Strategies::OAuth" do
       last_request.env["omniauth.error.type"] = :session_expired
     end
   end
+
+  describe "/auth/{name}/callback with wrong session" do
+    before do
+      stub_request(:post, "https://api.example.org/oauth/access_token").
+        to_return(:body => "oauth_token=yourtoken&oauth_token_secret=yoursecret")
+      get "/auth/example.org/callback", {:oauth_verifier => "dudeman"}, "rack.session" => {"oauth" => {"different-example.org" => {"callback_confirmed" => true}}}
+    end
+
+    it "should call fail! with :session_expired" do
+      expect(last_request.env["omniauth.error"]).to be_kind_of(::OmniAuth::NoSessionError)
+      last_request.env["omniauth.error.type"] = :session_expired
+    end
+  end
 end


### PR DESCRIPTION
Addresses issue #6 similar to solution proposed in #9 

It happened a few times for my users, will be happy to address this.
Any suggestions on how to make this pull request better are welcome.
