### PR TITLE
Using application/x-www-form-urlencoded as the default request content type when getting access_token

### DIFF
--- a/lib/omniauth/strategies/oauth.rb
+++ b/lib/omniauth/strategies/oauth.rb
@@ -53,7 +53,8 @@ module OmniAuth
           opts[:oauth_callback] = callback_url
         end
 
-        @access_token = request_token.get_access_token(opts)
+        callback_params = {}
+        @access_token = request_token.get_access_token(opts, callback_params)
         super
       rescue ::Timeout::Error => e
         fail!(:timeout, e)

--- a/spec/omniauth/strategies/oauth_spec.rb
+++ b/spec/omniauth/strategies/oauth_spec.rb
@@ -105,9 +105,14 @@ describe "OmniAuth::Strategies::OAuth" do
       expect(last_response.body).to eq("true")
     end
 
+    it "should set application/x-www-form-urlencoded as the Content-Type" do
+      expect(WebMock).to have_requested(:post, "https://api.example.org/oauth/access_token").
+        with { |req| req.headers["Content-Type"] == "application/x-www-form-urlencoded" }
+    end
+
     context "bad gateway (or any 5xx) for access_token" do
       before do
-        stub_request(:post, "https://api.example.org/oauth/access_token")  .
+        stub_request(:post, "https://api.example.org/oauth/access_token").
           to_raise(::Net::HTTPFatalError.new('502 "Bad Gateway"', nil))
         get "/auth/example.org/callback", {:oauth_verifier => "dudeman"}, "rack.session" => {"oauth" => {"example.org" => {"callback_confirmed" => true, "request_token" => "yourtoken", "request_secret" => "yoursecret"}}}
       end
@@ -120,7 +125,7 @@ describe "OmniAuth::Strategies::OAuth" do
 
     context "SSL failure" do
       before do
-        stub_request(:post, "https://api.example.org/oauth/access_token")  .
+        stub_request(:post, "https://api.example.org/oauth/access_token").
           to_raise(::OpenSSL::SSL::SSLError.new("SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed"))
         get "/auth/example.org/callback", {:oauth_verifier => "dudeman"}, "rack.session" => {"oauth" => {"example.org" => {"callback_confirmed" => true, "request_token" => "yourtoken", "request_secret" => "yoursecret"}}}
       end


### PR DESCRIPTION
First thank you for the awesome works!

Recently I am working on creating Open Bank Project OmniAuth strategy using `omniauth-oauth`, but keep hitting 401 unauthorized error during [the get access token phase](https://github.com/intridea/omniauth-oauth/blob/9d6a95a07ea117dd3e74093325a82485aaea3cf4/lib/omniauth/strategies/oauth.rb#L56), which is using [#get_access_token](https://github.com/oauth-xx/oauth-ruby/blob/f5652509c463627afd3c25ed9c9fa7b69901fd39/lib/oauth/consumer.rb#L105). Turned out if `{}` is not passed into `#get_access_token` as one of the `arguments`, code will run into [this part](https://github.com/oauth-xx/oauth-ruby/blob/f5652509c463627afd3c25ed9c9fa7b69901fd39/lib/oauth/consumer.rb#L372-L373) and the `Content-Type` of the request would be missing, which kinda violate the rule of OAuth 1.0 according to http://tools.ietf.org/html/rfc5849#section-3.4.1.3.1, which says

> The query component is parsed into a list
>       of name/value pairs by treating it as an
>       "application/x-www-form-urlencoded" string, separating the names
>       and values and decoding them as defined by
>       [W3C.REC-html40-19980424], Section 17.13.4.

This pull request fix the issue by implicitly declare the request body as `""` and set the content type as `application/x-www-form-urlencoded` during the get access token phase.
