### PR TITLE
Update oauth.rb for compatibility with rack v3.1+

### DIFF
--- a/lib/omniauth/strategies/oauth.rb
+++ b/lib/omniauth/strategies/oauth.rb
@@ -48,7 +48,7 @@ module OmniAuth
 
         opts = {}
         if session["oauth"][name.to_s]["callback_confirmed"]
-          opts[:oauth_verifier] = request["oauth_verifier"]
+          opts[:oauth_verifier] = request.params["oauth_verifier"]
         else
           opts[:oauth_callback] = callback_url
         end


### PR DESCRIPTION
This line causes logins to fail in rack v3.1+
https://github.com/omniauth/omniauth-oauth/blob/master/lib/omniauth/strategies/oauth.rb#L51

It must be changed from
`opts[:oauth_verifier] = request["oauth_verifier"]`
to
`opts[:oauth_verifier] = request.params["oauth_verifier"]`

Due to my Rails app's state, I was only able to test `request.params["oauth_verifier"]` going back to rack v2.2.4 where it continued to be functional.

Let me know if you'd prefer something like `Gem.loaded_specs["rack"].version >= Gem::Version.new("3.0")` to conditionally switch to the updated syntax.